### PR TITLE
Use \b to capture token boundaries

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -56,7 +56,7 @@ function buildRegex(language: string) {
 	tokens = tokens.concat(languageConfiguration["inlineOpenTokens"]);
 	tokens = tokens.concat(languageConfiguration["closeTokens"]);
 	tokens = tokens.concat(languageConfiguration["neutralTokens"]);
-	return RegExp("(^[ \t]*|[^\n \t][ \t]+)(" + tokens.join('|') + ")(\\b)", "gm");
+	return RegExp("(\\b)(" + tokens.join('|') + ")(\\b)", "gm");
 }
 
 function updateDecorations() {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -56,7 +56,7 @@ function buildRegex(language: string) {
 	tokens = tokens.concat(languageConfiguration["inlineOpenTokens"]);
 	tokens = tokens.concat(languageConfiguration["closeTokens"]);
 	tokens = tokens.concat(languageConfiguration["neutralTokens"]);
-	return RegExp("(^[ \t]*|[^\n \t][ \t]+)(" + tokens.join('|') + ")(\\s|\.|$)", "gm");
+	return RegExp("(^[ \t]*|[^\n \t][ \t]+)(" + tokens.join('|') + ")(\\b)", "gm");
 }
 
 function updateDecorations() {


### PR DESCRIPTION
Use \b to capture token boundaries.

More information is available here:
https://github.com/noplay/vscode-rainbow-end/issues/8

The change in action:

![image](https://user-images.githubusercontent.com/27440221/58644683-c830e700-82cf-11e9-8473-647e70103cec.png)

And for a much more complex file (from the gem `solidus_core`):

![image](https://user-images.githubusercontent.com/27440221/58644847-1e9e2580-82d0-11e9-95d8-d569ee9cbc7b.png)