### PR TITLE
fix: support ignore block nesting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.7.2
+
+By https://github.com/polvalente
+
+- Ignore blocks now support token nesting
+
 ## 0.7.1
 
 - Julia support
@@ -14,8 +20,10 @@ By https://github.com/polvalente
 - Allow matching for the first character in the document
 
 ## 0.6.1
+
 By https://github.com/DianeLooney/
-* Fix word detections
+
+- Fix word detections
 
 ## 0.6.0
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "license": "Apache-2.0",
     "displayName": "Rainbow End",
     "description": "This extension allows to identify keyword / end with colours.",
-    "version": "0.7.1",
+    "version": "0.7.2",
     "icon": "images/logo.png",
     "engines": {
         "vscode": "^1.29.0"
@@ -29,8 +29,7 @@
     ],
     "main": "./out/extension",
     "contributes": {
-        "colors": [
-            {
+        "colors": [{
                 "id": "rainbowend.deep1",
                 "description": "Rainbow End color 1",
                 "defaults": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,141 +1,224 @@
-'use strict';
+"use strict";
 
-import * as vscode from 'vscode';
-import { languages } from './languages';
-
+import * as vscode from "vscode";
+import { languages } from "./languages";
 
 const deepDecorations = [
-	vscode.window.createTextEditorDecorationType({
-		color: { id: "rainbowend.deep1" }
-	}),
-	vscode.window.createTextEditorDecorationType({
-		color: { id: "rainbowend.deep2" }
-	}),
-	vscode.window.createTextEditorDecorationType({
-		color: { id: "rainbowend.deep3" }
-	})
+  vscode.window.createTextEditorDecorationType({
+    color: { id: "rainbowend.deep1" }
+  }),
+  vscode.window.createTextEditorDecorationType({
+    color: { id: "rainbowend.deep2" }
+  }),
+  vscode.window.createTextEditorDecorationType({
+    color: { id: "rainbowend.deep3" }
+  })
 ];
 
 let timeout: NodeJS.Timer | null = null;
 let regExs: { [index: string]: RegExp } = {};
 
 export function activate(context: vscode.ExtensionContext) {
-	Object.keys(languages).forEach(language => {
-		regExs[language] = buildRegex(language);
-	});
+  Object.keys(languages).forEach(language => {
+    regExs[language] = buildRegex(language);
+  });
 
-	let activeEditor = vscode.window.activeTextEditor;
-	if (activeEditor) {
-		triggerUpdateDecorations(activeEditor);
-	}
+  let activeEditor = vscode.window.activeTextEditor;
+  if (activeEditor) {
+    triggerUpdateDecorations(activeEditor);
+  }
 
-	vscode.window.onDidChangeActiveTextEditor(editor => {
-		activeEditor = editor;
-		if (activeEditor) {
-			triggerUpdateDecorations(activeEditor);
-		}
-	}, null, context.subscriptions);
+  vscode.window.onDidChangeActiveTextEditor(
+    editor => {
+      activeEditor = editor;
+      if (activeEditor) {
+        triggerUpdateDecorations(activeEditor);
+      }
+    },
+    null,
+    context.subscriptions
+  );
 
-	vscode.workspace.onDidChangeTextDocument(event => {
-		if (activeEditor && event.document === activeEditor.document) {
-			triggerUpdateDecorations(activeEditor);
-		}
-	}, null, context.subscriptions);
+  vscode.workspace.onDidChangeTextDocument(
+    event => {
+      if (activeEditor && event.document === activeEditor.document) {
+        triggerUpdateDecorations(activeEditor);
+      }
+    },
+    null,
+    context.subscriptions
+  );
 }
 
 function triggerUpdateDecorations(activeEditor: vscode.TextEditor) {
-	if (timeout) {
-		clearTimeout(timeout);
-	}
-	timeout = setTimeout(updateDecorations, 250);
+  if (timeout) {
+    clearTimeout(timeout);
+  }
+  timeout = setTimeout(updateDecorations, 250);
 }
 
 function buildRegex(language: string) {
-
-	const languageConfiguration = languages[language];
-	let tokens: Array<string> = languageConfiguration["openTokens"];
-	tokens = tokens.concat(languageConfiguration["inlineOpenTokens"]);
-	tokens = tokens.concat(languageConfiguration["closeTokens"]);
-	tokens = tokens.concat(languageConfiguration["neutralTokens"]);
-	return RegExp("(\\b)(" + tokens.join('|') + ")(\\b)", "gm");
+  const languageConfiguration = languages[language];
+  let tokens: Array<string> = languageConfiguration["openTokens"];
+  tokens = tokens.concat(languageConfiguration["inlineOpenTokens"]);
+  tokens = tokens.concat(languageConfiguration["closeTokens"]);
+  tokens = tokens.concat(languageConfiguration["neutralTokens"]);
+  return RegExp("(\\b)(" + tokens.join("|") + ")(\\b)", "gm");
 }
 
-function ignoreInDelimiters(token_pairs: Array<{
-	open: string,
-	close: string
-}> | undefined, text: string) {
-	if (token_pairs) {
-		token_pairs.forEach(({
-			open: open_delim,
-			close: close_delim
-		}) => {
-			let regexp = RegExp(`${open_delim}[^${close_delim}]*${close_delim}`, "gm");
-			text = text.replace(regexp, (match) => {
-				return " ".repeat(match.length);
-			});
-		})
-	}
-	return text;
+function ignoreInDelimiters(
+  token_pairs:
+    | Array<{
+        open: string;
+        close: string;
+      }>
+    | undefined,
+  text: string
+) {
+  /* This function replaces text inside each token pair with spaces,
+	   so as to ignore the text between delimiters
+	   Also, if there is an unmatched character, the extension's coloring
+	   will be disabled for the remainder of the file */
+  if (token_pairs) {
+    token_pairs.forEach(({ open: open_delim, close: close_delim }) => {
+      let openRegexp = RegExp(`${open_delim}`, "gm");
+      let closeRegexp = RegExp(`${close_delim}`, "gm");
+
+      let indices = [];
+
+      let match = openRegexp.exec(text);
+      if (match == null) {
+        return;
+      }
+
+      while (match != null) {
+        indices.push({ index: match.index, type: "open" });
+        match = openRegexp.exec(text);
+      }
+
+      match = closeRegexp.exec(text);
+      if (match == null) {
+        return;
+      }
+
+      while (match != null) {
+        indices.push({ index: match.index, type: "close" });
+        match = closeRegexp.exec(text);
+      }
+
+      /* Sort by index */
+      indices = indices.sort(({ index: a }, { index: b }) => a - b);
+
+      let ignore_env_counter = 0;
+      let first_index = indices[0].index;
+
+      let index: number;
+      let type: string;
+
+      /* This isn't so inefficient in that it is
+	     O(indices.length), instead of O(text.length).
+	     Also, the list is already ordered, which is really helpful */
+      for ({ index: index, type: type } of indices) {
+        /* skip current token if trying to close when there is no open block
+           cannot just break because '\n' can be both a closing token and a
+           normal line end
+        */
+        if (type == "close" && ignore_env_counter == 0) {
+          continue;
+        }
+
+        /* if counter is zero, should begin an ignore block */
+        if (ignore_env_counter == 0) {
+          first_index = index;
+        }
+
+        if (type == "open") {
+          /* if it is an open token, always increment env counter */
+          ignore_env_counter++;
+        } else {
+          ignore_env_counter--;
+          /* if counter has reached zero after a closing token,
+             end ignore block */
+          let last_index = index;
+
+          /* Set ignore block slice as whitespace and keep the rest */
+          text =
+            text.slice(0, first_index) +
+            " ".repeat(last_index - first_index + 1) +
+            text.slice(last_index + 1);
+        }
+      }
+
+      if (ignore_env_counter != 0) {
+        /* Didn't close last block */
+        text =
+          text.slice(0, first_index) +
+          " ".repeat(text.length - first_index + 1);
+      }
+    });
+  }
+  return text;
 }
 
 function updateDecorations() {
-	const activeEditor = vscode.window.activeTextEditor;
-	if (!activeEditor) {
-		return;
-	}
-	const languageConfiguration = languages[activeEditor.document.languageId];
+  const activeEditor = vscode.window.activeTextEditor;
+  if (!activeEditor) {
+    return;
+  }
+  const languageConfiguration = languages[activeEditor.document.languageId];
 
-	let text = activeEditor.document.getText();
-	const options: vscode.DecorationOptions[][] = [];
-	deepDecorations.forEach(d => {
-		options.push([]);
-	});
-	let match;
-	let deep = 0;
+  let text = activeEditor.document.getText();
+  const options: vscode.DecorationOptions[][] = [];
+  deepDecorations.forEach(d => {
+    options.push([]);
+  });
+  let match;
+  let deep = 0;
 
-	// if we are not case sensitive, then ensure the case of text matches then keyworkd matches
-	if (!languageConfiguration.caseSensitive) {
-		text = text.toLowerCase();
-	}
-	// substitute all ignore intervals with spaces
-	// this ensures commented code or
-	// keywords inside strings are ignored properly
+  // if we are not case sensitive, then ensure the case of text matches then keyworkd matches
+  if (!languageConfiguration.caseSensitive) {
+    text = text.toLowerCase();
+  }
+  // substitute all ignore intervals with spaces
+  // this ensures commented code or
+  // keywords inside strings are ignored properly
 
-	// also, prepend a whitespace to allow matching the first character in document
-	// if needed
+  // also, prepend a whitespace to allow matching the first character in document
+  // if needed
 
-	text = ' ' + ignoreInDelimiters(languageConfiguration.ignoreInDelimiters, text);
-	while (match = regExs[activeEditor.document.languageId].exec(text)) {
-		const startIndex = match.index + match[1].length - 1; // Decrement to compensate for added character
-		const startPos = activeEditor.document.positionAt(startIndex);
-		const endPos = activeEditor.document.positionAt(startIndex + match[2].length);
-		const decoration: vscode.DecorationOptions = { range: new vscode.Range(startPos, endPos) };
+  text =
+    " " + ignoreInDelimiters(languageConfiguration.ignoreInDelimiters, text);
+  while ((match = regExs[activeEditor.document.languageId].exec(text))) {
+    const startIndex = match.index + match[1].length - 1; // Decrement to compensate for added character
+    const startPos = activeEditor.document.positionAt(startIndex);
+    const endPos = activeEditor.document.positionAt(
+      startIndex + match[2].length
+    );
+    const decoration: vscode.DecorationOptions = {
+      range: new vscode.Range(startPos, endPos)
+    };
 
-		if (languageConfiguration.closeTokens.indexOf(match[2]) > -1) {
-			if (deep > 0) {
-				deep -= 1;
-			}
-			options[deep % deepDecorations.length].push(decoration);
-		}
-		else if (languageConfiguration.neutralTokens.indexOf(match[2]) > -1) {
-			if (deep > 0) {
-				options[(deep - 1) % deepDecorations.length].push(decoration);
-			}
-		}
-		else if (languageConfiguration.openTokens.indexOf(match[2]) > -1) {
-			options[deep % deepDecorations.length].push(decoration);
-			deep += 1;
-		}
-		else {
-			if (match[1].length === 0 || match[1].match("^[\\s\n]+$")) {
-				options[deep % deepDecorations.length].push(decoration);
-				deep += 1;
-			}
-		}
-	}
+    if (languageConfiguration.closeTokens.indexOf(match[2]) > -1) {
+      if (deep > 0) {
+        deep -= 1;
+      }
+      options[deep % deepDecorations.length].push(decoration);
+    } else if (languageConfiguration.neutralTokens.indexOf(match[2]) > -1) {
+      if (deep > 0) {
+        options[(deep - 1) % deepDecorations.length].push(decoration);
+      }
+    } else if (languageConfiguration.openTokens.indexOf(match[2]) > -1) {
+      options[deep % deepDecorations.length].push(decoration);
+      deep += 1;
+    } else {
+      if (match[1].length === 0 || match[1].match("^[\\s\n]+$")) {
+        options[deep % deepDecorations.length].push(decoration);
+        deep += 1;
+      }
+    }
+  }
 
-	deepDecorations.forEach((deepDecoration, i) => {
-		activeEditor.setDecorations(deepDecoration, options[i]);
-	});
+  deepDecorations.forEach((deepDecoration, i) => {
+    activeEditor.setDecorations(deepDecoration, options[i]);
+  });
 }
-


### PR DESCRIPTION
Solves #18 and helps with #16

By design, a missing closing delim for the outermost open delim will make the rest of the file uncolored. This should help in identifying unmatched delimiters.