### PR TITLE
fix: only allow nesting if delimiters are different

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,21 @@
 # Changelog
 
+## [Unreleased]
+
+By https://github.com/polvalente
+
+- Fix 'ignoreInDelimiters' nesting
+
 ## 0.7.3
 
 By https://github.com/polvalente
+
 - Fix Lua support by adding 'do' as a neutralToken
 
 ## 0.7.2
 
 By https://github.com/polvalente
+
 - Ignore blocks now support token nesting
 
 ## 0.7.1


### PR DESCRIPTION
This solves the problem encountered with docstrings in #16.
Now, `"`, `'` and `"""` tokens bypass nesting. Maybe this could be improved by explicitly setting an `allowNesting` property for desired tokens in `languages.ts`. 