### PR TITLE
Add "elsif" to Crystal

### DIFF
--- a/src/languages.ts
+++ b/src/languages.ts
@@ -229,7 +229,7 @@ export const languages: {
       "do"
     ],
     closeTokens: ["end"],
-    neutralTokens: ["else", "elseif", "rescue", "ensure"]
+    neutralTokens: ["else", "elseif", "elsif", "rescue", "ensure"]
   },
   COBOL: {
     caseSensitive: false,


### PR DESCRIPTION
Allow use of the `elsif` construct in Crystal. Currently, only `elseif` is supported, but Crystal allows either one.