### PR TITLE
Added a way to configure more than 3 colors

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,19 @@
     ],
     "main": "./out/extension",
     "contributes": {
+        "configuration": {
+            "title": "rainbow-end",
+            "properties": {
+                "rainbow-end.colors": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "format": "color"
+                    },
+                    "description": "Specifies an override of the colors used for colorising. Replaces the theme defined colors if defined!"
+                }
+            }
+        },
         "colors": [
             {
                 "id": "rainbowend.deep1",
@@ -79,7 +92,6 @@
         "compile": "tsc -p ./",
         "lint": "eslint . --ext .ts,.tsx",
         "watch": "tsc -watch -p ./"
-
     },
     "devDependencies": {
         "@types/node": "^12.12.0",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,17 +3,29 @@
 import * as vscode from "vscode";
 import { languages } from "./languages";
 
-const deepDecorations = [
-  vscode.window.createTextEditorDecorationType({
-    color: { id: "rainbowend.deep1" }
-  }),
-  vscode.window.createTextEditorDecorationType({
-    color: { id: "rainbowend.deep2" }
-  }),
-  vscode.window.createTextEditorDecorationType({
-    color: { id: "rainbowend.deep3" }
-  })
-];
+const configSection = 'rainbow-end';
+
+function createDeepDecorations(): vscode.TextEditorDecorationType[] {
+  const colors: string[] | undefined = vscode.workspace.getConfiguration(configSection).get('colors');
+
+  const mappedColors = colors?.map(
+    (color) => vscode.window.createTextEditorDecorationType({ color })
+  );
+
+  return mappedColors ?? [
+    vscode.window.createTextEditorDecorationType({
+      color: { id: "rainbowend.deep1" }
+    }),
+    vscode.window.createTextEditorDecorationType({
+      color: { id: "rainbowend.deep2" }
+    }),
+    vscode.window.createTextEditorDecorationType({
+      color: { id: "rainbowend.deep3" }
+    })
+  ];
+}
+
+let deepDecorations = createDeepDecorations();
 
 let timeout: NodeJS.Timer | null = null;
 let regExs: { [index: string]: RegExp } = {};
@@ -43,6 +55,16 @@ export function activate(context: vscode.ExtensionContext) {
     event => {
       if (activeEditor && event.document === activeEditor.document) {
         triggerUpdateDecorations(activeEditor);
+      }
+    },
+    null,
+    context.subscriptions
+  );
+
+  vscode.workspace.onDidChangeConfiguration(
+    event => {
+      if (event.affectsConfiguration(configSection)) {
+        deepDecorations = createDeepDecorations();
       }
     },
     null,

--- a/src/languages.ts
+++ b/src/languages.ts
@@ -63,8 +63,8 @@ export const languages: {
       }
     ],
     inlineOpenTokens: [],
-    openTokens: ["function", "if", "while", "for"],
-    closeTokens: ["end"],
+    openTokens: ["function", "if", "while", "for", "repeat"],
+    closeTokens: ["end", "until"],
     neutralTokens: ["do", "then", "else", "elseif"]
   },
   elixir: {


### PR DESCRIPTION
## Description
I wanted to have more options for colors in my highlighting, and I saw how the default is hardcoded to just 3 colors, which is why I created this addition.

This PR adds a setting `"rainbow-end.colors"` which allows for overriding the configured colors with a variable amount of user-defined colors, which via an event listener allows for hot-reloading. This is also configurable through the settings UI, if wanted.

I also added support for `repeat`/`until` for Lua, as described in https://www.lua.org/manual/5.4/manual.html#3.3.4

## Example

```json
"rainbow-end.colors": [
  "#987654", "#547698", "#769854", "#abc123"
]
```

![image](https://user-images.githubusercontent.com/39386945/152972841-4d325ba1-a163-4a3a-9b58-166807c9d504.png)

## Review points

I don't know how to best handle that there are 2 ways to set the colors now, especially as I think differentiated support for different theme styles is really neat. My best bet is what I have submitted here: Just allowing the setting to be an override.

I am open to implement fixes and making this better based on feedback.