### PR TITLE
fix: doesn’t display image in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Rainbow End
 
-[![Marketplace Version](https://vsmarketplacebadge.apphb.com/version/jduponchelle.rainbow-end.svg)](https://marketplace.visualstudio.com/items?itemName=jduponchelle.rainbow-end) [![Installs](https://vsmarketplacebadge.apphb.com/installs/jduponchelle.rainbow-end.svg)](https://marketplace.visualstudio.com/items?itemName=jduponchelle.rainbow-end)
+[Installs](https://marketplace.visualstudio.com/items?itemName=jduponchelle.rainbow-end)
 
 This extension allows to identify keyword / end with colours.
 


### PR DESCRIPTION
The image in the README was broken. Originally, clicking on the image would take you to a linked destination.

 I propose a change that replacing the image with text.

Issue https://github.com/julien-duponchelle/vscode-rainbow-end/issues/49